### PR TITLE
feat: add GitHub connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ cd ..
 make seed
 ```
 
+- Ingest a GitHub repository as evidence
+
+```bash
+curl -X POST http://localhost:8088/github/repo \\
+  -H "Content-Type: application/json" \\
+  -d '{"url":"https://github.com/org/repo"}'
+```
+
 ### Env
 
 Edit `api/.env` to set provider, model, and keys. Default uses OpenAI `text-embedding-3-small` (1536 dims).

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,12 +1,13 @@
 from fastapi import FastAPI
 from .graph import ensure_indexes
-from .routes import evidence, link, search
+from .routes import evidence, link, search, github
 
 
 app = FastAPI(title="Second Brain API")
 app.include_router(evidence.router)
 app.include_router(link.router)
 app.include_router(search.router)
+app.include_router(github.router)
 
 
 @app.on_event("startup")

--- a/api/app/routes/github.py
+++ b/api/app/routes/github.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter
+from pydantic import BaseModel, HttpUrl
+from datetime import datetime
+import requests
+import base64
+import os
+from ..models import EvidenceIn
+from ..graph import upsert_evidence
+
+router = APIRouter(prefix="/github", tags=["github"])
+
+class RepoIn(BaseModel):
+    url: HttpUrl
+
+
+def _parse_repo(url: str) -> tuple[str, str]:
+    parts = url.rstrip('/').split('/')
+    if len(parts) < 2:
+        raise ValueError("Invalid repository URL")
+    return parts[-2], parts[-1]
+
+
+@router.post("/repo")
+def ingest_repo(repo: RepoIn):
+    owner, name = _parse_repo(str(repo.url))
+    headers = {}
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+    repo_api = f"https://api.github.com/repos/{owner}/{name}"
+    info = requests.get(repo_api, headers=headers).json()
+    readme_resp = requests.get(f"{repo_api}/readme", headers=headers)
+    if readme_resp.status_code == 200:
+        content = readme_resp.json().get("content", "")
+        text = base64.b64decode(content).decode("utf-8")
+    else:
+        text = ""
+    ev = EvidenceIn(
+        url=repo.url,
+        title=info.get("full_name", f"{owner}/{name}"),
+        source="github",
+        published_at=datetime.fromisoformat(
+            info.get("created_at", datetime.utcnow().isoformat() + "Z").replace("Z", "+00:00")
+        ),
+        text=text,
+    )
+    eid = upsert_evidence(ev)
+    return {"id": eid}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,4 +3,5 @@ uvicorn[standard]==0.30.0
 neo4j==5.23.0
 python-dotenv==1.0.1
 pydantic==2.7.4
+requests==2.32.3
 


### PR DESCRIPTION
## Summary
- add GitHub ingestion endpoint that stores repository README as an evidence
- wire route into app and document usage
- add requests dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689edb884d8c8330b1f2326e3a4cc42c